### PR TITLE
eslint error: Delete ␍ prettier/prettier 에러 문제

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,7 @@
     "prettier/prettier": [
       "error",
       {
-        "endOfLine": "lf"
+        "endOfLine": "auto"
       }
     ]
   }


### PR DESCRIPTION
## 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #17 
## 구현 기능 및 변경 사항

<!-- 구현한 내용에 대해 설명해주세요 -->
원인
엔드라인 시퀀스가 LF로 지정되어있어서 윈도우에서는 CRLF를 사용하기 때문에 충돌 문제 발생

해결 방법
.eslintrc.json에서 endOfLine lf를 auto로 변경해주면 해결된다함
